### PR TITLE
Fix Linux build failing Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies
-      run: sudo apt install libsdl2-dev
+      run: |
+        sudo apt update
+        sudo apt install libsdl2-dev
     - name: Compile
       run: make release
       env:
@@ -23,7 +25,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies
-      run: sudo apt install gcc-mingw-w64-x86-64
+      run: |
+        sudo apt update
+        sudo apt install gcc-mingw-w64-x86-64
     - name: Compile
       run: make release PLATFORM=mingw32
       env:


### PR DESCRIPTION
Make sure Debian package list is up-to-date so it pulls latest version instead of trying old version that may not exist on mirror.

----

Follow up to <https://github.com/KuehnhammerTobias/ioqw-devel/commit/d36f85482ac41ecb86ac37f8576f7b1c9c958301#commitcomment-42039440> mentioning failing to get http://security.ubuntu.com/ubuntu/pool/main/libx/libx11/libx11-xcb-dev_1.6.3-1ubuntu2.1_amd64.deb. libx11-xcb-dev_1.6.3-1ubuntu2.**2**_amd64.deb is latest available (checked [that directory](http://security.ubuntu.com/ubuntu/pool/main/libx/libx11/)) so update the package list. This is a common thing that happens on Debian/Ubuntu.