### PR TITLE
Use MSYS2 on Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,15 +21,16 @@ jobs:
         path: build/*.zip
   windows:
     name: Windows
-    runs-on: ubuntu-16.04
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v2
-    - name: Install Dependencies
-      run: |
-        sudo apt update
-        sudo apt install gcc-mingw-w64-x86-64
+    - uses: msys2/setup-msys2@v2
+      with:
+        release: false
+        install: git zip make mingw-w64-x86_64-gcc
     - name: Compile
-      run: make release PLATFORM=mingw32
+      shell: msys2 {0}
+      run: make release
       env:
         ARCHIVE: 1
     - uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -1207,7 +1207,7 @@ define DO_REF_STR
 $(echo_cmd) "REF_STR $<"
 $(Q)rm -f $@
 $(Q)echo "const char *fallbackShader_$(notdir $(basename $<)) =" >> $@
-$(Q)cat $< | sed -e 's/^/\"/;s/$$/\\n\"/' | tr -d '\r' >> $@
+$(Q)cat $< | sed -e 's/^\(.*\)$$/\"\1\\n\"/' | tr -d '\r' >> $@
 $(Q)echo ";" >> $@
 endef
 


### PR DESCRIPTION
Use MSYS2 on Windows Server for Windows build instead of building on Linux. This solves the incompatibility with `\\n` in DO_REF_STR when run on Github Actions Windows Server using PowerShell, make from Chocolatey, and sed from Git for Windows.

Also change DO_REF_STR to use \1 like ioquake3 now does.